### PR TITLE
Add manual approval step before production deployment in CI workflow

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -189,9 +189,22 @@ jobs:
     with:
       environment: test
 
+  approval-prod:
+    needs: evaluate-test
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+      url: https://prod.example.com
+    steps:
+      - name: Await manual approval before production deployment
+        uses: reviewdog/action-wait-for-approval@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          message: 'Manual approval required to proceed to production deployment.'
+
   deploy-prod:
     runs-on: ubuntu-latest
-    needs: evaluate-test
+    needs: approval-prod
     environment:
       name: prod
       url: https://prod.example.com
@@ -245,7 +258,6 @@ jobs:
             --federated-credential-provider "github" \
             --tenant-id "$AZURE_TENANT_ID"
         shell: bash
-      
       # - name: Set AZD environment
       #   run: azd env set AZURE_ENV_NAME "$AZURE_ENV_NAME"
       # - name: Pre-deployment validation


### PR DESCRIPTION
This pull request introduces a new manual approval step before deploying to the production environment in the Azure DevOps workflow. It also includes minor cleanup of commented-out lines in the workflow file.

### Workflow Enhancements:

* [`.github/workflows/azure-dev.yml`](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7R192-R207): Added a new `approval-prod` job that requires manual approval before proceeding to the `deploy-prod` job. This ensures an additional layer of review for production deployments. The `deploy-prod` job now depends on `approval-prod` instead of `evaluate-test`.

### Minor Cleanup:

* [`.github/workflows/azure-dev.yml`](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L248): Removed trailing whitespace and retained commented-out lines for potential future use.