### PR TITLE
Remove manual approval step before production deployment in CI workflow

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -189,22 +189,9 @@ jobs:
     with:
       environment: test
 
-  approval-prod:
-    needs: evaluate-test
-    runs-on: ubuntu-latest
-    environment:
-      name: prod
-      url: https://prod.example.com
-    steps:
-      - name: Await manual approval before production deployment
-        uses: reviewdog/action-wait-for-approval@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          message: 'Manual approval required to proceed to production deployment.'
-
   deploy-prod:
     runs-on: ubuntu-latest
-    needs: approval-prod
+    needs: evaluate-test
     environment:
       name: prod
       url: https://prod.example.com


### PR DESCRIPTION
This pull request modifies the Azure DevOps workflow configuration to streamline the deployment process by removing the manual approval step before production deployment.

Changes to deployment workflow:

* [`.github/workflows/azure-dev.yml`](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L192-R194): Removed the `approval-prod` job, which required manual approval before deploying to production. The `deploy-prod` job now directly depends on the `evaluate-test` job, eliminating the intermediate approval step.